### PR TITLE
Add static grant matcher site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# frontend
+# Grant Matcher Frontend
+
+This repository contains a small static website that allows researchers to select their name and view matching grants. The data is stored in the `grants.json` and `matches.json` files at the repository root.
+
+## Running Locally
+
+Use any static file server to preview the site locally. If you have Python installed, run:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open [http://localhost:8000/app/](http://localhost:8000/app/) in your browser.
+
+## Deployment
+
+The site is a pure static website (HTML/CSS/JS). It can be deployed easily on any static hosting service. Popular options include:
+
+- **GitHub Pages** – push the repository to GitHub and enable GitHub Pages in the repository settings. Point the Pages source to the `main` branch.
+- **Netlify** – create a new site from Git, set the publish directory to the repository root, and deploy.
+
+No build step is required.
+
+## Palette
+
+The design uses a white background with deep navy (`#213646`) and vivid cyan (`#1DBEE6`) accents.

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Grant Matcher</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Grant Matcher</h1>
+  </header>
+  <main>
+    <div class="selector">
+      <label for="researcher-select">Select your name:</label>
+      <select id="researcher-select"></select>
+    </div>
+    <section id="grants"></section>
+  </main>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/app/script.js
+++ b/app/script.js
@@ -1,0 +1,43 @@
+async function loadData() {
+  const [matchesResp, grantsResp] = await Promise.all([
+    fetch('../matches.json'),
+    fetch('../grants.json')
+  ]);
+  const matches = await matchesResp.json();
+  const grants = await grantsResp.json();
+  return { matches, grants };
+}
+
+function populateResearchers(matches) {
+  const select = document.getElementById('researcher-select');
+  matches.forEach((m, i) => {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = m.name;
+    select.appendChild(opt);
+  });
+  select.addEventListener('change', () => showGrants(matches, grantsData));
+}
+
+function showGrants(matches, grants) {
+  const select = document.getElementById('researcher-select');
+  const container = document.getElementById('grants');
+  container.innerHTML = '';
+  const idx = select.value;
+  if (idx === '') return;
+  const grantIds = matches[idx].grants;
+  grantIds.forEach(id => {
+    const g = grants.find(gr => gr.grant_id === id);
+    if (!g) return;
+    const div = document.createElement('div');
+    div.className = 'grant';
+    div.innerHTML = `<h3>${g.title}</h3><p><strong>Provider:</strong> ${g.provider}</p>`;
+    container.appendChild(div);
+  });
+}
+
+let grantsData = [];
+loadData().then(({ matches, grants }) => {
+  grantsData = grants;
+  populateResearchers(matches);
+});

--- a/app/styles.css
+++ b/app/styles.css
@@ -1,0 +1,41 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #ffffff;
+  color: #213646;
+  margin: 0;
+  padding: 0;
+}
+
+header {
+  background: #213646;
+  color: #ffffff;
+  padding: 1rem;
+  text-align: center;
+}
+
+.selector {
+  margin: 1rem;
+}
+
+select {
+  padding: 0.5rem;
+  border: 1px solid #213646;
+  border-radius: 4px;
+}
+
+#grants {
+  margin: 1rem;
+}
+
+.grant {
+  border: 1px solid #213646;
+  border-left: 4px solid #1DBEE6;
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  background: #ffffff;
+}
+
+.grant h3 {
+  margin-top: 0;
+  color: #1DBEE6;
+}

--- a/matches.json
+++ b/matches.json
@@ -1,5 +1,14 @@
 [
   {
-    "name": "Halevi, Sharon",
-    "grants": [
-      
+    "name": "Sharon Halevi",
+    "grants": [46905912, 47395944]
+  },
+  {
+    "name": "Alex Green",
+    "grants": [47135709]
+  },
+  {
+    "name": "Dana Cohen",
+    "grants": [47470287, 47761339]
+  }
+]


### PR DESCRIPTION
## Summary
- set up a simple static site under `app/`
- style with deep navy and vivid cyan palette
- load researcher and grant info from repo JSON files
- document how to run and deploy
- provide sample researcher/grant matches

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68729794583c832e9dfafed73b2ef6b8