### PR TITLE
Handle reranked_matches and show reasoning

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -273,6 +273,12 @@ main {
   line-height: 1.45;
 }
 
+.match-reason {
+  margin-top: 0.5rem;
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
 /* ========== Footer with LinkedIn ========== */
 footer {
   display: flex;


### PR DESCRIPTION
## Summary
- add detection for `reranked_matches.json`
- capture `match_reason` per grant and display it
- gracefully fall back to `matches.json` when reranked data is not present
- show reasoning text with an "Ask AI Why" label
- style the reasoning text in grant cards

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_687e8b949724832e856d66a25edf021b