### PR TITLE
Implement voting and stats widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ No build step is required; the site consists only of HTML, CSS and JavaScript fi
 ## Colors
 
 The design uses a white background with deep navy (`#213646`) and vivid cyan (`#1DBEE6`) accents.
+
+## Voting & Health Widget
+
+The site integrates with a backend service to record likes and dislikes for each
+grant. Users can vote on the grants displayed in their recommendations using the
+green **Like** or red **Dislike** buttons. Vote totals update instantly without
+reloading the page.
+
+A small banner at the top of the page shows overall voting statistics fetched
+from the backend. These stats refresh automatically every minute.

--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
         <button id="tab-stats" class="tab" role="tab" aria-selected="false" aria-controls="dashboard">Statistics</button>
       </nav>
     </header>
+    <div id="health-widget" class="health-widget" aria-live="polite"></div>
     <section id="dashboard" class="dashboard hidden" role="tabpanel" aria-labelledby="tab-stats">
       <div class="stats-dashboard">
         <div class="stat">

--- a/styles.css
+++ b/styles.css
@@ -426,3 +426,38 @@ footer .linkedin:hover { transform: scale(1.15); }
 .dataTables_wrapper .dataTables_filter {
   display: none; /* hide default search */
 }
+
+/* ======= Voting buttons ======= */
+.vote-buttons {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.vote-btn {
+  background: var(--accent);
+  border: none;
+  color: #fff;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+.vote-btn.like.active { background: #2ecc71; }
+.vote-btn.dislike.active { background: #e74c3c; }
+
+/* ======= Health widget ======= */
+.health-widget {
+  max-width: 900px;
+  margin: 1rem auto;
+  padding: 0.5rem 1rem;
+  background: #fff;
+  border: 2px solid var(--primary);
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.08);
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- add new voting buttons for each grant card
- refresh votes and user selection from backend
- show site health statistics widget
- document voting features in README

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68847ebf1348832e97f7b5129635fa69