### PR TITLE
Add voting and health widgets

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
         <button id="tab-stats" class="tab" role="tab" aria-selected="false" aria-controls="dashboard">Statistics</button>
       </nav>
     </header>
+    <div id="health-widget" class="health-widget" aria-live="polite"></div>
     <section id="dashboard" class="dashboard hidden" role="tabpanel" aria-labelledby="tab-stats">
       <div class="stats-dashboard">
         <div class="stat">

--- a/styles.css
+++ b/styles.css
@@ -426,3 +426,52 @@ footer .linkedin:hover { transform: scale(1.15); }
 .dataTables_wrapper .dataTables_filter {
   display: none; /* hide default search */
 }
+
+/* ======== Health & voting ======== */
+.health-widget {
+  max-width: 900px;
+  margin: 1rem auto;
+  padding: 0.5rem 1rem;
+  background: #ffffff;
+  border: 2px solid var(--primary);
+  border-radius: 10px;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.vote-section {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.5rem;
+}
+
+.vote-btn {
+  background: #ffffff;
+  border: 1px solid var(--primary);
+  border-radius: 6px;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.vote-btn.active-like {
+  background: #d4f5d0;
+  border-color: #2e8b57;
+  color: #2e8b57;
+}
+
+.vote-btn.active-dislike {
+  background: #f8d6d6;
+  border-color: #c0392b;
+  color: #c0392b;
+}
+
+.vote-msg {
+  margin-left: 0.5rem;
+  color: #c0392b;
+  font-size: 0.8rem;
+}


### PR DESCRIPTION
## Summary
- integrate like/dislike voting via backend API
- display site health stats that auto refresh
- style new voting buttons and health widget

## Testing
- `npx prettier -c index.html script.js styles.css`

------
https://chatgpt.com/codex/tasks/task_e_68847ebf1348832e97f7b5129635fa69