### PR TITLE
Add voting and health widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
         <button id="tab-stats" class="tab" role="tab" aria-selected="false" aria-controls="dashboard">Statistics</button>
       </nav>
     </header>
+    <div id="health-widget" class="health-widget" aria-live="polite"></div>
     <section id="dashboard" class="dashboard hidden" role="tabpanel" aria-labelledby="tab-stats">
       <div class="stats-dashboard">
         <div class="stat">

--- a/styles.css
+++ b/styles.css
@@ -426,3 +426,43 @@ footer .linkedin:hover { transform: scale(1.15); }
 .dataTables_wrapper .dataTables_filter {
   display: none; /* hide default search */
 }
+
+.vote-box {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.4rem;
+}
+
+.vote-btn {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 0.3rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.vote-btn.like-btn.active { background: #2ecc71; }
+.vote-btn.dislike-btn.active { background: #e74c3c; }
+
+.vote-msg {
+  margin-top: 0.3rem;
+  font-size: 0.85rem;
+  color: var(--primary);
+}
+
+.health-widget {
+  background: var(--primary);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  text-align: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Summary
- enable like/dislike voting on grants via backend API
- show backend health information in a small widget
- update styles for vote buttons and health banner

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68847ebf1348832e97f7b5129635fa69