### PR TITLE
Add like/dislike voting to grant cards

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -426,3 +426,65 @@ footer .linkedin:hover { transform: scale(1.15); }
 .dataTables_wrapper .dataTables_filter {
   display: none; /* hide default search */
 }
+
+/* === Voting === */
+.vote-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.4rem;
+}
+
+.vote-btn {
+  border: 2px solid var(--primary);
+  background: #fff;
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1.2;
+  color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: box-shadow 0.15s ease;
+}
+
+.vote-btn:hover {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+}
+
+.vote-btn:focus {
+  outline: 2px dashed var(--accent);
+  outline-offset: 2px;
+}
+
+.vote-btn.liked {
+  background: #28a745;
+  color: #fff;
+}
+
+.vote-btn.disliked {
+  background: #dc3545;
+  color: #fff;
+}
+
+.vote-bar .count {
+  min-width: 1.2em;
+  text-align: center;
+  font-size: 0.9rem;
+  visibility: hidden;
+}
+
+@media (min-width: 400px) {
+  .grant h3 {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .grant h3 + .vote-bar {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- set CURRENT_USER constant placeholder
- inject a vote bar in each grant card and fetch vote state
- implement voting module with REST calls and optimistic UI
- style the vote buttons and responsive layout

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68849f065420832ea3c652f938d2954c