### PR TITLE
Improve frontend performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,15 +6,19 @@
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220%200%20100%20100%22><text y=%22.9em%22 font-size=%2290%22>🧙</text></svg>" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://code.jquery.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.datatables.net" crossorigin />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
-    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
-    <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.dataTables.min.css" />
-    <link rel="stylesheet" href="https://cdn.datatables.net/colreorder/1.6.2/css/colReorder.dataTables.min.css" />
-    <link rel="stylesheet" href="https://cdn.datatables.net/responsive/2.5.0/css/responsive.dataTables.min.css" />
+    <link rel="preload" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" />
+    <link rel="preload" href="https://cdn.datatables.net/buttons/2.4.1/css/buttons.dataTables.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" />
+    <link rel="preload" href="https://cdn.datatables.net/colreorder/1.6.2/css/colReorder.dataTables.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" />
+    <link rel="preload" href="https://cdn.datatables.net/responsive/2.5.0/css/responsive.dataTables.min.css" as="style" onload="this.onload=null;this.rel='stylesheet'" />
 
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-FKE4HL7881"></script>
@@ -96,18 +100,7 @@
       </a>
     </footer>
 
-    <script src="https://code.jquery.com/jquery-3.7.0.min.js"></script>
-    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
-    <script src="https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js"></script>
-    <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js"></script>
-    <script src="https://cdn.datatables.net/buttons/2.4.1/js/buttons.colVis.min.js"></script>
-    <script src="https://cdn.datatables.net/colreorder/1.6.2/js/dataTables.colReorder.min.js"></script>
-    <script src="https://cdn.datatables.net/responsive/2.5.0/js/dataTables.responsive.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/jquery.mark.min.js"></script>
-    <script src="https://cdn.datatables.net/plug-ins/1.13.6/features/mark.js/datatables.mark.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
-    <script src="script.js"></script>
-    <script src="teaser.js"></script>
+    <script src="script.js" defer></script>
+    <script src="teaser.js" defer></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,43 @@ let researcherNames = [];
 let providerChart;
 let deadlineChart;
 let grantsTable;
+let dataTablesReady;
+let chartReady;
+
+function loadScript(src) {
+  if (document.querySelector(`script[src="${src}"]`)) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.onload = () => resolve();
+    s.onerror = reject;
+    document.head.appendChild(s);
+  });
+}
+
+function ensureDataTables() {
+  if (dataTablesReady) return dataTablesReady;
+  const libs = [
+    'https://code.jquery.com/jquery-3.7.0.min.js',
+    'https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js',
+    'https://cdn.datatables.net/buttons/2.4.1/js/dataTables.buttons.min.js',
+    'https://cdn.datatables.net/buttons/2.4.1/js/buttons.html5.min.js',
+    'https://cdn.datatables.net/buttons/2.4.1/js/buttons.colVis.min.js',
+    'https://cdn.datatables.net/colreorder/1.6.2/js/dataTables.colReorder.min.js',
+    'https://cdn.datatables.net/responsive/2.5.0/js/dataTables.responsive.min.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js',
+    'https://cdnjs.cloudflare.com/ajax/libs/mark.js/8.11.1/jquery.mark.min.js',
+    'https://cdn.datatables.net/plug-ins/1.13.6/features/mark.js/datatables.mark.js'
+  ];
+  dataTablesReady = libs.reduce((p, src) => p.then(() => loadScript(src)), Promise.resolve());
+  return dataTablesReady;
+}
+
+function ensureChart() {
+  if (chartReady) return chartReady;
+  chartReady = loadScript('https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js');
+  return chartReady;
+}
 
 // TODO: replace 'anon' with real user id from auth cookie when available
 const CURRENT_USER = 'anon';
@@ -25,7 +62,7 @@ function showLandingWizard() {
   const container = document.getElementById('grants');
   container.innerHTML = `
     <div class="landing-wizard">
-      <img src="assets/wizardoc.png" alt="Cartoon robot scanning grant proposals">
+      <img src="assets/wizardoc.png" alt="Cartoon robot scanning grant proposals" width="1536" height="1024" loading="lazy">
     </div>`;
 }
 
@@ -379,13 +416,13 @@ function showTab(name) {
     dash.classList.remove('hidden');
     statTab.classList.add('active');
     statTab.setAttribute('aria-selected', 'true');
-    requestAnimationFrame(showDashboard);
+    ensureChart().then(() => requestAnimationFrame(showDashboard));
     track('view_stats_tab');
   } else if (name === 'grants') {
     grantsSec.classList.remove('hidden');
     grantsTab.classList.add('active');
     grantsTab.setAttribute('aria-selected', 'true');
-    if (!grantsTable) initGrantsTable();
+    ensureDataTables().then(() => { if (!grantsTable) initGrantsTable(); });
     track('view_grants_tab');
   } else {
     rec.classList.remove('hidden');
@@ -509,6 +546,12 @@ async function init() {
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('sw.js');
+  });
+}
 
 // ===== Voting module =====
 const API_BASE = 'https://ggm-backend.onrender.com';

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,27 @@
+const CACHE_NAME = 'ggmatcher-static-v1';
+const URLS = [
+  '/',
+  '/index.html',
+  '/styles.css',
+  '/script.js',
+  '/teaser.js',
+  '/grants.json',
+  '/matches.json',
+  '/reranked_matches.json',
+  '/assets/wizardoc.png'
+];
+self.addEventListener('install', event => {
+  event.waitUntil(caches.open(CACHE_NAME).then(c => c.addAll(URLS)));
+});
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(res => res || fetch(event.request))
+  );
+});
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))
+    ))
+  );
+});

--- a/teaser.js
+++ b/teaser.js
@@ -9,7 +9,7 @@ function showTeaser() {
   const card = document.createElement('div');
   card.className = 'teaser-card';
   card.innerHTML = `
-    <img src="assets/wizardoc.png" alt="Cartoon robot scanning grant proposals">
+    <img src="assets/wizardoc.png" alt="Cartoon robot scanning grant proposals" width="1536" height="1024" loading="lazy">
     <p>Didn\u2019t spot the perfect call?<br>
     \u26A1 Let our AI scout the web for fresh opportunities tailored to <em>${selectedName}</em>!</p>
     <button class="teaser-cta">Engage the Robot \ud83e\udd16</button>


### PR DESCRIPTION
## Summary
- preconnect to CDN assets
- lazy load large wizard images
- lazy load DataTables and Chart.js scripts
- register a simple service worker for offline caching

## Testing
- `node -e "const fs=require('fs');const code=fs.readFileSync('script.js','utf8');try{new Function(code);console.log('ok');}catch(e){console.log('err',e.message);}"`

------
https://chatgpt.com/codex/tasks/task_e_6889d96c1374832ebfc1d13e828bb486