### PR TITLE
Tie votes to selected researcher name

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -141,6 +141,14 @@ main {
 }
 #researcher-input:focus { border-color: var(--accent); }
 
+/* Display currently selected researcher */
+.current-researcher {
+  grid-column: 1 / -1;
+  font-weight: 600;
+  color: var(--primary);
+  margin-bottom: 1rem;
+}
+
 /* Suggestions dropdown */
 .suggestions {
   position: absolute;


### PR DESCRIPTION
## Summary
- store the chosen researcher name globally
- include the researcher name in `/vote` API requests
- display the selected researcher above the grant list
- prevent voting until a name is selected

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_688967a9dc1c832ea747d94b0b1e285e