### PR TITLE
Tie votes to selected researcher name

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,8 +7,8 @@ let providerChart;
 let deadlineChart;
 let grantsTable;
 
-// TODO: replace 'anon' with real user id from auth cookie when available
-const CURRENT_USER = 'anon';
+// The researcher currently being viewed/voted on
+let currentResearcherName = null;
 
 // ---------- Google Analytics event helper ----------
 function track(eventName, params = {}) {
@@ -86,6 +86,7 @@ function updateSuggestions(value) {
 }
 
 function selectResearcher(name) {
+  currentResearcherName = name;
   document.getElementById('researcher-input').value = name;
   document.getElementById('suggestions').style.display = 'none';
   showGrants(name);
@@ -379,6 +380,11 @@ function showGrants(name) {
   const grantsContainer = document.getElementById('grants');
   grantsContainer.innerHTML = '';
 
+  const heading = document.createElement('h2');
+  heading.className = 'current-researcher';
+  heading.textContent = `Recommendations for ${name}`;
+  grantsContainer.appendChild(heading);
+
   const match = matchesData.find((m) => m.name === name);
   if (!match) return;
 
@@ -503,21 +509,28 @@ const api = {
     const text = await res.text();
     return text ? JSON.parse(text) : null;
   },
-  userVote(id, user) {
-    return this.fetch(`/vote/${id}/${user}`);
+  userVote(id) {
+    if (!currentResearcherName) return Promise.resolve(null);
+    return this.fetch(`/vote/${id}/${encodeURIComponent(currentResearcherName)}`);
   },
   post(id, type) {
+    if (!currentResearcherName) {
+      return Promise.reject(new Error('No researcher selected'));
+    }
     return this.fetch('/vote', {
       method: 'POST',
       body: JSON.stringify({
         grant_id: id,
-        researcher_id: CURRENT_USER,
+        researcher_name: currentResearcherName,
         action: type
       })
     });
   },
   remove(id) {
-    return this.fetch(`/vote/${id}/${CURRENT_USER}`, { method: 'DELETE' });
+    if (!currentResearcherName) {
+      return Promise.reject(new Error('No researcher selected'));
+    }
+    return this.fetch(`/vote/${id}/${encodeURIComponent(currentResearcherName)}`, { method: 'DELETE' });
   }
 };
 
@@ -573,7 +586,7 @@ function renderVoteBar(cardEl, grantId) {
   likeBtn.addEventListener('keydown', keyHandler);
   dislikeBtn.addEventListener('keydown', keyHandler);
 
-  api.userVote(grantId, CURRENT_USER)
+  api.userVote(grantId)
     .then(d => setState(bar, d ? d.action : null))
     .catch(() => {});
 }
@@ -581,6 +594,10 @@ function renderVoteBar(cardEl, grantId) {
 async function handleVoteClick(e) {
   const btn = e.currentTarget;
   const bar = btn.parentElement;
+  if (!currentResearcherName) {
+    alert('Please select your name before voting.');
+    return;
+  }
   if (bar.dataset.busy) return;
   bar.dataset.busy = '1';
   setTimeout(() => delete bar.dataset.busy, 300);

--- a/script.js
+++ b/script.js
@@ -483,6 +483,12 @@ async function init() {
   const input = document.getElementById('researcher-input');
   input.addEventListener('input', (e) => updateSuggestions(e.target.value));
   input.addEventListener('focus', (e) => updateSuggestions(e.target.value));
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+      const first = document.querySelector('#suggestions .suggestion-item');
+      if (first) selectResearcher(first.textContent);
+    }
+  });
   document.addEventListener('click', (e) => {
     if (!document.querySelector('.selector').contains(e.target)) {
       document.getElementById('suggestions').style.display = 'none';

--- a/styles.css
+++ b/styles.css
@@ -141,6 +141,14 @@ main {
 }
 #researcher-input:focus { border-color: var(--accent); }
 
+/* Display currently selected researcher */
+.current-researcher {
+  grid-column: 1 / -1;
+  font-weight: 600;
+  color: var(--primary);
+  margin-bottom: 1rem;
+}
+
 /* Suggestions dropdown */
 .suggestions {
   position: absolute;


### PR DESCRIPTION
## Summary
- store the chosen researcher name globally
- show recommendations heading for the selected researcher
- update the voting API calls to send `researcher_name`
- prevent voting until a name is selected

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_688967a9dc1c832ea747d94b0b1e285e