### PR TITLE
Store researcher identity for votes

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,8 +7,17 @@ let providerChart;
 let deadlineChart;
 let grantsTable;
 
-// TODO: replace 'anon' with real user id from auth cookie when available
-const CURRENT_USER = 'anon';
+// --- Voting identity helpers ----------------------------------------------
+let currentUser = localStorage.getItem('researcher_id') || null;
+
+function setCurrentUser(id) {
+  currentUser = id;
+  localStorage.setItem('researcher_id', id);
+}
+
+function getCurrentUser() {
+  return currentUser;
+}
 
 // ---------- Google Analytics event helper ----------
 function track(eventName, params = {}) {
@@ -88,6 +97,7 @@ function updateSuggestions(value) {
 function selectResearcher(name) {
   document.getElementById('researcher-input').value = name;
   document.getElementById('suggestions').style.display = 'none';
+  setCurrentUser(name);             // <-- STORE researcher ID
   showGrants(name);
   track('select_researcher', { researcher_name: name });
 }
@@ -491,6 +501,7 @@ document.addEventListener('DOMContentLoaded', init);
 // ===== Voting module =====
 const API_BASE = 'https://ggm-backend.onrender.com';
 
+// -------------------- API wrapper ------------------------------------------
 const api = {
   async fetch(path, options = {}) {
     const opts = { ...options };
@@ -503,21 +514,22 @@ const api = {
     const text = await res.text();
     return text ? JSON.parse(text) : null;
   },
-  userVote(id, user) {
-    return this.fetch(`/vote/${id}/${user}`);
+  userVote(id, user) {                            // always encode path parts
+    return this.fetch(`/vote/${id}/${encodeURIComponent(user)}`);
   },
   post(id, type) {
     return this.fetch('/vote', {
       method: 'POST',
       body: JSON.stringify({
         grant_id: id,
-        researcher_id: CURRENT_USER,
+        researcher_id: getCurrentUser(),
         action: type
       })
     });
   },
   remove(id) {
-    return this.fetch(`/vote/${id}/${CURRENT_USER}`, { method: 'DELETE' });
+    return this.fetch(`/vote/${id}/${encodeURIComponent(getCurrentUser())}`,
+                      { method: 'DELETE' });
   }
 };
 
@@ -573,9 +585,11 @@ function renderVoteBar(cardEl, grantId) {
   likeBtn.addEventListener('keydown', keyHandler);
   dislikeBtn.addEventListener('keydown', keyHandler);
 
-  api.userVote(grantId, CURRENT_USER)
-    .then(d => setState(bar, d ? d.action : null))
-    .catch(() => {});
+  if (getCurrentUser()) {            // only query once researcher is chosen
+    api.userVote(grantId, getCurrentUser())
+      .then(d => setState(bar, d ? d.action : null))
+      .catch(() => {});
+  }
 }
 
 async function handleVoteClick(e) {


### PR DESCRIPTION
## Summary
- track researcher selection in localStorage and reuse it for voting
- encode researcher IDs in vote API calls
- only fetch existing vote after a researcher is chosen

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_688bb6e4f06c832eb915ffff623a1be2